### PR TITLE
feat: populate span links

### DIFF
--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -99,7 +99,7 @@ function populateSpanReference(reference, traceUrl) {
           candidateSpan => candidateSpan.spanID === reference.spanID
         );
         if (reference.span && typeof reference.span.processID === 'string') {
-          // We need to reassign `reference.span`, hence ignore no-param-reassign linting rule.
+          // We need to reassign `reference.span.process`, hence ignore no-param-reassign linting rule.
           // eslint-disable-next-line
           reference.span.process = referenceTrace.processes[reference.span.processID];
         }

--- a/packages/jaeger-ui/src/api/jaeger.js
+++ b/packages/jaeger-ui/src/api/jaeger.js
@@ -105,7 +105,7 @@ function populateSpanReference(reference, traceUrl) {
         }
       })
       // Catch and swallow error. If we can't parse the reference, Jaeger UI should continue to function
-      // `reference.span` population.
+      // without `reference.span` population.
       .catch(e => {
         // eslint-disable-next-line
         console.error(e);


### PR DESCRIPTION
# Intent

Populate the `span.references` member appropriately so that we see the below:

![image](https://user-images.githubusercontent.com/13295571/223901876-78ac8ca8-b3e0-49b2-9462-6b0929f01ed2.png)

Instead of this (which provides 0 contextualisation 🤮 )

![image](https://user-images.githubusercontent.com/13295571/223901910-0e0437d7-c3ec-4ee6-bed2-6ee123f3624c.png)

## Why not do this in Jaeger Query?

Doing this in Jaeger Query requires us to update a data model used across its codebase. This is simpler, more targeted, and we expect to re-investigate how to visualise these traces once we decide on a more permanent trace visualisation option (i.e. this will only be used in the short term presumably).

Note that this will send a trace query for each link in a trace. Since we don't use span links commonly, this is a presumed insignificant cost.

## What happens if the linked span hasn't yet arrived in storage?

It reverts to the non-contextualised version.
